### PR TITLE
adding bDCt in BDCI constant (data.py) 

### DIFF
--- a/console.js
+++ b/console.js
@@ -1,0 +1,2 @@
+// hey this is a comment
+console.log("hello")

--- a/mk8dx/data.py
+++ b/mk8dx/data.py
@@ -720,7 +720,7 @@ class Track(Enum):
     )
     RRRD = (
         39,
-        'Rainbow Road',
+        'N64 Rainbow Road',
         'レインボーロード',
         'rRRd',
         '64虹',
@@ -738,7 +738,7 @@ class Track(Enum):
     )
     DRR = (
         41,
-        'Rainbow Road',
+        'SNES Rainbow Road',
         'レインボーロード',
         'dRR',
         'SFC虹',
@@ -999,13 +999,13 @@ class Track(Enum):
         'メリー',
         {'bmm', 'mm', 'ﾒﾘｰﾒﾘｰﾏｳﾝﾃﾝ', 'ﾒﾘﾏ', 'ﾒﾘｰﾒﾘｰ', 'ﾒﾘｰ', 'ﾒﾘﾔﾏ', 'ﾒﾘ山'}
     )
-    BRR = (
+    BRR7 = (
         71,
-        'Rainbow Road',
+        '3DS Rainbow Road',
         'レインボーロード',
-        'bRR',
+        'bRR7',
         '3DS虹',
-        {'brr', '3dsﾆｼﾞ', '3ds虹', '7ﾆｼﾞ', '7虹'},
+        {'brr7', '3dsﾆｼﾞ', '3ds虹', '7ﾆｼﾞ', '7虹'},
         Console.N3DS
     )
     BAD = (
@@ -1079,13 +1079,13 @@ class Track(Enum):
         {'bssy', 'ssy', 'bsis', 'sis', 'singapore', 'ｼﾝｶﾞﾎﾟｰﾙｽﾌﾟﾗｯｼｭ', 'ｼﾝｶﾞﾎﾟｰﾙ'},
         Console.TOUR
     )
-    BADA = (
+    BATD = (
         80,
         'Athens Dash',
         'アテネポリス',
-        'bADa',
+        'bAtD',
         'アテネ',
-        {'bada', 'ada', 'athens', 'ｱﾃﾈﾎﾟﾘｽ', 'ｱﾃﾈ'},
+        {'batd', 'ada', 'athens', 'ｱﾃﾈﾎﾟﾘｽ', 'ｱﾃﾈ'},
         Console.TOUR
     )
     BDC = (

--- a/mk8dx/data.py
+++ b/mk8dx/data.py
@@ -1173,7 +1173,6 @@ class Track(Enum):
         'Daisy Circuit',
         'デイジーサーキット',
         'bDCi',
-        'bDCt',
         'デイサ',
         {'bdci', 'dci','bdct', 'ﾃﾞｲｼﾞｰｻｰｷｯﾄ', 'ﾃﾞｲｻ'},
         Console.WII

--- a/mk8dx/data.py
+++ b/mk8dx/data.py
@@ -1173,8 +1173,9 @@ class Track(Enum):
         'Daisy Circuit',
         'デイジーサーキット',
         'bDCi',
+        'bDCt',
         'デイサ',
-        {'bdci', 'dci', 'ﾃﾞｲｼﾞｰｻｰｷｯﾄ', 'ﾃﾞｲｻ'},
+        {'bdci', 'dci','bdct', 'ﾃﾞｲｼﾞｰｻｰｷｯﾄ', 'ﾃﾞｲｻ'},
         Console.WII
     )
     BPPC = (

--- a/mk8dx/data.py
+++ b/mk8dx/data.py
@@ -1004,8 +1004,8 @@ class Track(Enum):
         '3DS Rainbow Road',
         'レインボーロード',
         'bRR7',
-        '3DS虹',
-        {'brr7', '3dsﾆｼﾞ', '3ds虹', '7ﾆｼﾞ', '7虹'},
+        '7虹',
+        {'brr7', 'rr7', '3dsﾆｼﾞ', '3ds虹', '7ﾆｼﾞ', '7虹'},
         Console.N3DS
     )
     BAD = (
@@ -1085,7 +1085,7 @@ class Track(Enum):
         'アテネポリス',
         'bAtD',
         'アテネ',
-        {'batd', 'ada', 'athens', 'ｱﾃﾈﾎﾟﾘｽ', 'ｱﾃﾈ'},
+        {'batd', 'atd', 'bada', 'ada', 'athens', 'ｱﾃﾈﾎﾟﾘｽ', 'ｱﾃﾈ'},
         Console.TOUR
     )
     BDC = (
@@ -1149,4 +1149,75 @@ class Track(Enum):
         'バンクーバー',
         {'bvv', 'vv', 'vancouver', 'ﾊﾞﾝｸｰﾊﾞｰﾊﾞﾚｰ', 'ﾊﾞﾝｸｰﾊﾞｰ'},
         Console.TOUR
+    )
+    BRA = (
+        88,
+        'Rome Avanti',
+        'ローマアバンティ',
+        'bRA',
+        'ローマ',
+        {'bra', 'ra', 'rome', 'ﾛｰﾏｱﾊﾞﾝﾃｨ', 'ﾛｰﾏ'},
+        Console.TOUR
+    )
+    BDKM = (
+        89,
+        'DK Mountain',
+        'DKマウンテン',
+        'bDKM',
+        'DKマウンテン',
+        {'bdkm', 'dkm', 'dkﾏｳﾝﾃﾝ', 'dkﾔﾏ', 'dk山'},
+        Console.GCN
+    )
+    BDCI = (
+        90,
+        'Daisy Circuit',
+        'デイジーサーキット',
+        'bDCi',
+        'デイサ',
+        {'bdci', 'dci', 'ﾃﾞｲｼﾞｰｻｰｷｯﾄ', 'ﾃﾞｲｻ'},
+        Console.WII
+    )
+    BPPC = (
+        91,
+        'Piranha Plant Cove',
+        'パックンしんでん',
+        'bPPC',
+        'しんでん',
+        {'bppc', 'ppc', 'ﾊﾟｯｸﾝｼﾝﾃﾞﾝ', 'ﾊﾟｸｼﾝ', 'ｼﾝﾃﾞﾝ'}
+    )
+    BMD = (
+        92,
+        'Madrid Drive',
+        'マドリードグランデ',
+        'bMD',
+        'マドリード',
+        {'bmd', 'md', 'madrid', 'ﾏﾄﾞﾘｰﾄﾞｸﾞﾗﾝﾃﾞ', 'ﾏﾄﾞﾘｰﾄﾞ'},
+        Console.TOUR
+    )
+    BRIW = (
+        93,
+        'Rosalina\'s Ice World',
+        'ロゼッタプラネット',
+        'bRIW',
+        'ロゼプラ',
+        {'briw', 'riw', 'ﾛｾｯﾀﾌﾟﾗﾈｯﾄ', 'ﾛｾﾌﾟﾗ'},
+        Console.N3DS
+    )
+    BBC3 = (
+        94,
+        'Bowser\'s Castle 3',
+        'クッパじょう3',
+        'bBC3',
+        'クッパじょう',
+        {'bbc3', 'bbc', 'bc3', 'ｸｯﾊﾟｼﾞｮｳ3', 'ｸｯﾊﾟｼﾞｮｳ', 'ｸｯﾊﾟ城'},
+        Console.SNES
+    )
+    BRR = (
+        95,
+        'Wii Rainbow Road',
+        'レインボーロード',
+        'bRR',
+        'Wii虹',
+        {'brr', 'brrw', 'rrw', 'wiiﾆｼﾞ', 'wiiﾚｲﾝﾎﾞｰﾛｰﾄﾞ', 'wii虹', 'wiiﾆｼﾞ', 'ｳｨｰﾆｼﾞ'},
+        Console.WII
     )


### PR DESCRIPTION
um hi. I appreciate if you merged my pull request because I add more abbra for daisy circuit because in lounge server does use "bDCt" for emote. the abrra in mk8dx api does use "bDCi" instead of "bDCt" (like in lounge server emote) for your api and sheat bot does use bDCi so its confusing everyone in many server so i decide to pull request and please merge it :)